### PR TITLE
added stub open-api spec + corresponding routes, prettier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ test/types/index.js
 
 # compiled app
 dist
+
+# unused
+_unused/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": true,
+  "arrowParens": "avoid",
+  "printWidth": 140,
+  "trailingComma": "es5"
+}

--- a/README.md
+++ b/README.md
@@ -16,5 +16,16 @@ After cloning this repository:
 - run `pnpm build` to build the project for production
 - run `pnpm start` to start the server in production mode
 
+# Development Cycle
+- create a local branch for the ticket you are working on. **All tasks must have a corresponding ticket.**:
+  - e.g. `git checkout -b feature/23-add-login-route` (for a ticket with id 23). If it's a bug, do something like `git checkout bug/23-fix-login-route` instead.
+- commit your changes locally, e.g.:
+ - `git add .`
+ - `git commit -m "I added the new login route"`
+- create a PR:
+ - `git push origin feature/23-add-login-route`
+ - click on the link offered by git cli to open a new PR in your browser (Or, login to github, find the branch you just pushed, and create a new PR for it).
+- once the PR is merged, you can delete the branch you created.
+
 ## Learn More
 To learn Fastify, check out the [Fastify documentation](https://fastify.dev/docs/latest/).

--- a/package.json
+++ b/package.json
@@ -7,11 +7,13 @@
     "test": "test"
   },
   "scripts": {
-    "test": "npm run build:ts && tsc -p test/tsconfig.json && c8 node --test -r ts-node/register test/**/*.ts",
-    "start": "npm run build:ts && fastify start -l info dist/app.js",
-    "build:ts": "tsc",
+    "clean": "rm -rf dist",
+    "test": "npm run build && tsc -p test/tsconfig.json && c8 node --test -r ts-node/register test/**/*.ts",
+    "start": "npm run build && fastify start -l info dist/app.js",
+    "copy": "cp -r src/api-specs/ dist/api-specs/",
+    "build": "npm run copy && tsc",
     "watch:ts": "tsc -w",
-    "dev": "npm run build:ts && concurrently -k -p \"[{name}]\" -n \"TypeScript,App\" -c \"yellow.bold,cyan.bold\" \"npm:watch:ts\" \"npm:dev:start\"",
+    "dev": "npm run build && concurrently -k -p \"[{name}]\" -n \"TypeScript,App\" -c \"yellow.bold,cyan.bold\" \"npm:watch:ts\" \"fastify start -l info dist/app.js\"",
     "dev:start": "fastify start --ignore-watch=.ts$ -w -l info -P dist/app.js",
     "routes": "fastify print-routes -P dist/app.js"
   },
@@ -21,6 +23,8 @@
   "dependencies": {
     "@fastify/autoload": "^5.0.0",
     "@fastify/sensible": "^5.0.0",
+    "@fastify/swagger": "^8.14.0",
+    "@scalar/fastify-api-reference": "^1.20.27",
     "fastify": "^4.26.1",
     "fastify-cli": "^6.1.1",
     "fastify-plugin": "^4.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ dependencies:
   '@fastify/sensible':
     specifier: ^5.0.0
     version: 5.5.0
+  '@fastify/swagger':
+    specifier: ^8.14.0
+    version: 8.14.0
+  '@scalar/fastify-api-reference':
+    specifier: ^1.20.27
+    version: 1.20.27(fastify-html@0.3.3)(fastify-plugin@4.5.1)(fastify@4.26.2)
   fastify:
     specifier: ^4.26.1
     version: 4.26.2
@@ -105,6 +111,18 @@ packages:
       vary: 1.1.2
     dev: false
 
+  /@fastify/swagger@8.14.0:
+    resolution: {integrity: sha512-sGiznEb3rl6pKGGUZ+JmfI7ct5cwbTQGo+IjewaTvtzfrshnryu4dZwEsjw0YHABpBA+kCz3kpRaHB7qpa67jg==}
+    dependencies:
+      fastify-plugin: 4.5.1
+      json-schema-resolver: 2.0.0
+      openapi-types: 12.1.3
+      rfdc: 1.3.1
+      yaml: 2.4.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@istanbuljs/schema@0.1.3:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
@@ -136,6 +154,19 @@ packages:
   /@lukeed/ms@2.0.2:
     resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
     engines: {node: '>=8'}
+    dev: false
+
+  /@scalar/fastify-api-reference@1.20.27(fastify-html@0.3.3)(fastify-plugin@4.5.1)(fastify@4.26.2):
+    resolution: {integrity: sha512-fSLu2QeJk1uM7MM3h5yTCWzTBFXfJZzkKNlo7FG2nTEEuN5mDVXJf7DaGzp87Hj+OcrwxKcfFMNhMdi+KYQIaQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      fastify: ^4.0.0
+      fastify-html: ^0.3.0
+      fastify-plugin: ^4.0.0
+    dependencies:
+      fastify: 4.26.2
+      fastify-html: 0.3.3
+      fastify-plugin: 4.5.1
     dev: false
 
   /@tsconfig/node10@1.0.10:
@@ -535,6 +566,13 @@ packages:
       - supports-color
     dev: false
 
+  /fastify-html@0.3.3:
+    resolution: {integrity: sha512-gXOrdGOd7AWxMMmZl2esd/MgenEn5i9CApO7d6dkXZV/8kNn3/dm/VfkRUfTzvpVJUAsYM2FR+6bYHKcsC8p7w==}
+    dependencies:
+      fastify-plugin: 4.5.1
+      ghtml: 1.2.1
+    dev: false
+
   /fastify-plugin@4.5.1:
     resolution: {integrity: sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==}
     dev: false
@@ -642,6 +680,11 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
     dev: true
+
+  /ghtml@1.2.1:
+    resolution: {integrity: sha512-pULT0AVOeotMcqtHx4OE5qeFJTL8C3jb6MM4mY82qgXPh8NRx+PtmxJ/NQYH9D32+7SDSfhvaozU12AjyeRK+g==}
+    engines: {node: '>=18'}
+    dev: false
 
   /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -797,6 +840,17 @@ packages:
       fast-deep-equal: 3.1.3
     dev: false
 
+  /json-schema-resolver@2.0.0:
+    resolution: {integrity: sha512-pJ4XLQP4Q9HTxl6RVDLJ8Cyh1uitSs0CzDBAz1uoJ4sRD/Bk7cFSXL1FUXDW3zJ7YnfliJx6eu8Jn283bpZ4Yg==}
+    engines: {node: '>=10'}
+    dependencies:
+      debug: 4.3.4
+      rfdc: 1.3.1
+      uri-js: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
     dev: false
@@ -907,6 +961,10 @@ packages:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
+
+  /openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
+    dev: false
 
   /p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -1401,6 +1459,12 @@ packages:
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  /yaml@2.4.1:
+    resolution: {integrity: sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==}
+    engines: {node: '>= 14'}
+    hasBin: true
+    dev: false
 
   /yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}

--- a/src/api-specs/temp-projects.yaml
+++ b/src/api-specs/temp-projects.yaml
@@ -1,0 +1,114 @@
+openapi: '3.0.2'
+info:
+  title: TEMP Projects API
+  version: '1.0'
+servers:
+  - url: http://localhost:3000/v0/
+paths:
+  /projects:
+    get:
+      operationId: getProjects,
+      summary: Get all projects
+      description: Get all projects across the entire platform
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectListResponse'
+  /projects/owned-by/{userId}:
+    get:
+      operationId: getProjectsOwnedByUser,
+      summary: Get all projects owned by user
+      description: Get all projects across the entire platform owned by the given user
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectListResponse'
+      parameters:
+      - name: userId
+        in: path
+        required: true
+        description: the userId for the project owner
+        schema:
+          type: string
+  /projects/with-member/{userId}:
+    get:
+      operationId: getProjectsWithMember,
+      summary: Get all projects that user is member of
+      description: Get all projects across the entire platform that the given user is a member of
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectListResponse'
+      parameters:
+      - name: userId
+        in: path
+        required: true
+        description: the userId for the user participating in the project
+        schema:
+          type: string
+  /projects/{projectId}:
+    get:
+      operationId: getProjectById,
+      summary: Get specific project
+      description: Get the project with the given projectId
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectResponse'
+      parameters:
+      - name: projectId
+        in: path
+        required: true
+        description: the projectId of the project to retrieve
+        schema:
+          type: string
+components:
+  schemas:
+    ProjectResponse:
+      type: object
+      required:
+        - project
+      properties:
+        project:
+          $ref: "#/components/schemas/Project"
+    ProjectListResponse:
+      type: object
+      required:
+        - projects
+      properties:
+        projects:
+          type: array
+          maxItems: 10
+          items:
+            $ref: "#/components/schemas/Project"
+    Project:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        approxDuration:
+          type: string
+    Projects:
+      type: array
+      maxItems: 10
+      items:
+        $ref: "#/components/schemas/Project"

--- a/src/app.ts
+++ b/src/app.ts
@@ -9,7 +9,7 @@ const options: AppOptions = {}
 const app: FastifyPluginAsync<AppOptions> = async (fastify, opts): Promise<void> => {
   // Place here your custom code!
   const apiSpecs = join(__dirname, 'api-specs')
-  const yamlSpec = `${apiSpecs}/temp-projects.yaml`
+  const yamlSpec = join(apiSpecs, 'temp-projects.yaml')
 
   // see: https://github.com/fastify/fastify-swagger#static
   void fastify.register(require('@fastify/swagger'), {

--- a/src/data/sample.json
+++ b/src/data/sample.json
@@ -1,0 +1,157 @@
+{
+  "projects": [
+    {
+      "id": "1",
+      "name": "Artemis",
+      "description": "The Artemis program is a Moon exploration program led by NASA and its partners, including ESA, JAXA, DLR, ASI, ISA, and CSA. It was established in 2017 with the goal of establishing a permanent base on the Moon to facilitate human missions to Mars",
+      "approxDuration": "3 months"
+    },
+    {
+      "id": "2",
+      "name": "Apollo",
+      "description": "Project Apollo was a comprehensive space program led by NASA and the United States government, aimed at achieving the goal of landing a man on the moon and returning him safely to Earth before the end of the 1960s",
+      "approxDuration": "5 months"
+    },
+    {
+      "id": "3",
+      "name": "Rocket to Mars",
+      "description": "We are going to Mars! is the fourth planet from the Sun and is the second-smallest planet in the Solar System, being larger than only Mercury. In the English language, Mars is named for the Roman god of war.",
+      "approxDuration": "10 years"
+    }
+  ],
+  "users": [
+    {
+      "id": "1",
+      "username": "John Doe",
+      "email": "john@doe.com",
+      "appRole": "admin",
+      "projectsOwned": ["1"],
+      "isMemberOfProjects": ["1"],
+      "targetIndustryRoles": ["CTO", "Lead Engineer"]
+    },
+    {
+      "id": "2",
+      "username": "Jane Smith",
+      "email": "jane@smith.com",
+      "appRole": "user",
+      "projectsOwned": [],
+      "isMemberOfProjects": ["1", "2"],
+      "targetIndustryRoles": ["QA Analyst"]
+    },
+    {
+      "id": "3",
+      "name": "Bob Johnson",
+      "email": "bob@johnson.com",
+      "appRole": "user",
+      "projectsOwned": ["2", "3"],
+      "isMemberOfProjects": ["2", "3"],
+      "targetIndustryRoles": ["Lead Engineer", "Fullstack Developer"]
+    },
+    {
+      "id": "4",
+      "name": "Alice Williams",
+      "email": "alice@williams.com",
+      "appRole": "user",
+      "projectsOwned": [],
+      "isMemberOfProjects": ["3"],
+      "targetIndustryRoles": ["Data Engineer", "Machine Learning Engineer"]
+    },
+    {
+      "id": "5",
+      "name": "Charlie Brown",
+      "email": "charlie@brown.com",
+      "appRole": "user",
+      "projectsOwned": [],
+      "isMemberOfProjects": ["1"],
+      "targetIndustryRoles": ["Product Manager"]
+    }
+  ],
+  "IndustryRoles": [
+    {
+      "id": "1",
+      "name": "CTO",
+      "description": "Chief Technology Officer",
+      "coreSkills": ["Research & Innovation Management", "Cloud Architecture Design"]
+    },
+    {
+      "id": "2",
+      "name": "QA Analyst",
+      "description": "Assure the quality of delivered solutions",
+      "coreSkills": ["Testing", "Test Planning & Management", "Issues Management"]
+    },
+    {
+      "id": "3",
+      "name": "Lead Engineer",
+      "description": "Leading engineering teams to success",
+      "coreSkills": ["Task Planning & Management", "Test Planning & Management", "Resource Planning & Management", "Cloud Architecture Design"]
+    },
+    {
+      "id": "4",
+      "name": "Fullstack Developer",
+      "description": "Implementation of all tiers of application software",
+      "coreSkills": ["Task Planning & Management", "Issue Investigation & Resolution", "Managing Design Assets", "Navigate Collaborative Design Tools", "API Services Implementation", "Web/UX Services Implementation",  "Basic Data Modeling", "Database Access Layer Implementation", "CI/CD Pipeline Implementation"]
+    },
+    {
+      "id": "5",
+      "name": "Frontend Developer",
+      "description": "Implementation of user-facing applications",
+      "coreSkills": ["Task Planning & Management", "Web/UX Services Implementation", "Managing Design Assets", "Navigate Collaborative Design Tools"]
+    },
+    {
+      "id": "6",
+      "name": "Backend Developer",
+      "description": "Implementation of application backend resources & services",
+      "coreSkills": ["Task Planning & Management", "API Services Implementation", "Basic Data Modeling", "Database Access Layer Implementation", "CI/CD Pipeline Implementation"]
+    },
+    {
+      "id": "8",
+      "name": "Cloud DevOPs Engineer",
+      "description": "Deployment & operation of application resources",
+      "coreSkills": ["Task Planning & Management", "CI/CD Pipeline Implementation", "Cloud Infrastructure & Services Provisioning", "Backup & Recovery Procedures", "Security Procedures", "Cloud Architecture Design"]
+    },
+    {
+      "id": "9",
+      "name": "Data Scientist",
+      "description": "Answering business/organisational questions with data",
+      "coreSkills": ["Task Planning & Management", "Data Querying & Analysis", "Data Visualization & Reporting"]
+    },
+    {
+      "id": "10",
+      "name": "Data Engineer",
+      "description": "Implementation of data ingestion, processing, and storage",
+      "coreSkills": ["Task Planning & Management", "Data Processing & Stream Processing", "Data Storage", "Data Querying & Analysis", "Data Modeling"]
+    },
+    {
+      "id": "11",
+      "name": "Machine Learning Engineer",
+      "description": "Implementation of ML models & services",
+      "coreSkills": ["Task Planning & Management", "Machine Learning", "Deep Learning", "Data Querying & Analysis"]
+    },
+    {
+      "id": "12",
+      "name": "Product Manager",
+      "description": "Product management & product-led decision making",
+      "coreSkills": ["Task Planning & Management", "Product Features Management & Roadmapping", "Product Testing & Feedback Management"]
+    }
+  ],
+  "coreSkills": [
+    "Research & Innovation Management",
+    "Cloud Architecture Design",
+    "Task Planning & Management",
+    "Test Planning & Management",
+    "Resource Planning & Management",
+    "Issues Management",
+    "Data Querying & Analysis",
+    "Data Visualization & Reporting",
+    "Data Processing & Stream Processing",
+    "Data Storage",
+    "Data Modeling",
+    "Database Access Layer Implementation",
+    "CI/CD Pipeline Implementation",
+    "Cloud Infrastructure & Services Provisioning",
+    "Backup & Recovery Procedures",
+    "Security Procedures",
+    "Product Features Management & Roadmapping",
+    "Product Testing & Feedback Management"
+  ]
+}

--- a/src/routes/v0/projects/index.ts
+++ b/src/routes/v0/projects/index.ts
@@ -1,0 +1,42 @@
+import fs from 'fs'
+import { FastifyRequest, FastifyReply } from 'fastify'
+import { FastifyPluginAsync } from 'fastify'
+
+import type { ReqByProjectId, ReqByUserId, ResProject, ResProjectList, SampleData } from './types.ts'
+const data: SampleData = JSON.parse(fs.readFileSync('src/data/sample.json', 'utf8'))
+
+const getProjects = async (_req: FastifyRequest, _resp: FastifyReply): Promise<ResProjectList> => {
+  return { projects: data.projects }
+}
+
+const getProjectById = async (req: FastifyRequest<ReqByProjectId>, _resp: FastifyReply): Promise<ResProject> => {
+  const { projectId } = req.params
+  return { project: data.projects.find(project => project.id === projectId) }
+}
+
+const getProjectsOwnedByUser = async (req: FastifyRequest<ReqByUserId>, _resp: FastifyReply): Promise<ResProjectList> => {
+  const { userId } = req.params
+  const targetUser = data.users.find(user => user.id === userId)
+  if (!targetUser) {
+    throw new Error('User not found')
+  }
+  return { projects: data.projects.filter(project => targetUser.projectsOwned.includes(project.id)) }
+}
+
+const getProjectsWithMember = async (req: FastifyRequest<ReqByUserId>, _resp: FastifyReply): Promise<ResProjectList> => {
+  const { userId } = req.params
+  const targetUser = data.users.find(user => user.id === userId)
+  if (!targetUser) {
+    throw new Error('User not found')
+  }
+  return { projects: data.projects.filter(project => targetUser.isMemberOfProjects.includes(project.id)) }
+}
+
+const projectsPlugin: FastifyPluginAsync = async (fastify, opts): Promise<void> => {
+  fastify.get('/', getProjects)
+  fastify.get('/owned-by/:userId', getProjectsOwnedByUser)
+  fastify.get('/with-member/:userId', getProjectsWithMember)
+  fastify.get('/:projectId', getProjectById)
+}
+
+export default projectsPlugin

--- a/src/routes/v0/projects/types.ts
+++ b/src/routes/v0/projects/types.ts
@@ -1,0 +1,41 @@
+export interface Project {
+  id: string;
+  name: string;
+  description: string;
+  approxDuration: string;
+}
+
+export interface User {
+  id : string
+  username : string
+  email : string
+  appRole: string
+  projectsOwned : string[]
+  isMemberOfProjects : string[]
+  targetIndustryRoles : string[]
+}
+
+export interface ReqByProjectId  {
+  Params: {
+    projectId: string;
+  }
+}
+
+export interface ReqByUserId  {
+  Params: {
+    userId: string;
+  }
+}
+
+export interface ResProject {
+  project: Project | undefined;
+}
+
+export interface ResProjectList {
+  projects: Project[];
+}
+
+export interface SampleData {
+  projects: Project[];
+  users: User[];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,14 +7,6 @@
     "strictPropertyInitialization": false,
     "baseUrl": "src",
     "emitDecoratorMetadata": true,
-    "paths": {
-      "@entity/*": ["entity/*"],
-      "@controllers/*": ["controllers/*"]
-    }
-  },
-  "tsc-alias": {
-    "verbose": false,
-    "resolveFullPaths": true
   },
   "include": ["src/**/*.ts", "src"],
   "assets":["src/api-specs/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,20 @@
   "extends": "fastify-tsconfig",
   "compilerOptions": {
     "outDir": "dist",
-    "sourceMap": true
+    "sourceMap": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "baseUrl": "src",
+    "emitDecoratorMetadata": true,
+    "paths": {
+      "@entity/*": ["entity/*"],
+      "@controllers/*": ["controllers/*"]
+    }
   },
-  "include": ["src/**/*.ts"]
+  "tsc-alias": {
+    "verbose": false,
+    "resolveFullPaths": true
+  },
+  "include": ["src/**/*.ts", "src"],
+  "assets":["src/api-specs/*"]
 }


### PR DESCRIPTION
Added prettier and some other tooling, but mainly:
- added a stub openapi spec
- stubbed impl of routes using a sample json file
- added auto-generated documentation for exercising and testing the api (you will need to pull this repo and run it to access it)

**API Reference / Documentation Page**
![image](https://github.com/colabco/cbld-api/assets/6601801/bd7c04e1-88bc-4cfb-a499-04acab7142be)

** API Routes **
These are just nonsense routes to get us going
```
└── / (GET, HEAD)
    ├── docs (GET, HEAD)
    │   └── /@scalar/fastify-api-reference/js/browser.js (GET, HEAD)
    ├── example (GET, HEAD)
    │   └── / (GET, HEAD)
    └── v0/projects (GET, HEAD)
        └── / (GET, HEAD)
            ├── owned-by/:userId (GET, HEAD)
            ├── with-member/:userId (GET, HEAD)
            └── :projectId (GET, HEAD)
```
:pencil: **Note**:
- the json sample file is expected to grow / change
- the open-api spec is expected to grow / change

